### PR TITLE
Handle 0 tasks in milestone

### DIFF
--- a/task-bot.py
+++ b/task-bot.py
@@ -12,6 +12,8 @@ from github.Label import Label
 
 
 def as_percentage(a: float, b: float) -> int:
+    if b == 0:
+        return 0
     return floor((a / b) * 100)
 
 


### PR DESCRIPTION
Currently this script will crash if there are zero tasks in a milestone.

Whilst it is opinionated behavior, we have to return a number.

0 was chosen over 100 as we cannot complete any tasks in a milestone if there are none to complete.

This patch is currently deployed in SRO slack.